### PR TITLE
pass Transcriber's attributes to load_model

### DIFF
--- a/openlrc/transcribe.py
+++ b/openlrc/transcribe.py
@@ -22,7 +22,7 @@ class Transcriber:
         self.device = device
 
     def transcribe(self, audio_path, batch_size=8):
-        whisper_model = whisperx.load_model('large-v2', compute_type='float16', device=self.device)
+        whisper_model = whisperx.load_model(self.model_name, compute_type=self.compute_type, device=self.device)
         audio = whisperx.load_audio(audio_path)
 
         with Timer('Base Whisper Transcription'):


### PR DESCRIPTION
Hi, thanks for providing this very useful package.

I just noticed the arguments to `whisperx.load_model` were hard coded. 

With this small modification the users can specify different device types or models

```python
t1 = Transcriber(device='cpu', compute_type='float32')`
t1.transcribe(audio_file)
```