### PR TITLE
add punctuators deps to poetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test.py
 /data/
 /dist/
 /openfaker.egg-info/
+__pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ rich = "^12.6.0"
 tqdm = "^4.65.0"
 audioread = "^3.0.0"
 opencc = "^1.1.1"
+punctuators = "^0.0.5"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/zh-plus/Open-Lyrics/issues"


### PR DESCRIPTION
Hello again :)

After following the installation instructions on README, the "punctuators" package is not getting installed.

This line is giving a module not found error. 
https://github.com/zh-plus/Open-Lyrics/blob/master/openlrc/transcribe.py#LL7C6-L7C17

adding it to poetry solves it